### PR TITLE
pruebas de pico de piedra con double

### DIFF
--- a/test/herramientas/PruebasPico.java
+++ b/test/herramientas/PruebasPico.java
@@ -220,4 +220,42 @@ public class PruebasPico {
         Assert.assertEquals(0, picoMetal.durabilidad());
     }
 
+    @Test
+    public void test18PicoPiedraGolpeaMaderaYSeReduceSuDurabilidad() {
+
+        Madera bloqueMadera = new Madera();
+        Pico picoPiedra = new Pico(new Piedra());
+
+        double durabilidadPico = picoPiedra.durabilidad();
+        int fuerzaPicoPiedra = picoPiedra.fuerza();
+        picoPiedra.golpear(bloqueMadera);
+
+        Assert.assertEquals(picoPiedra.durabilidad(),durabilidadPico - fuerzaPicoPiedra);
+    }
+
+    @Test
+    public void test19PicoPiedraGolpeaPiedraYSeReduceSuDurabilidad() {
+
+        Piedra bloquePiedra = new Piedra();
+        Pico picoPiedra = new Pico(new Piedra());
+
+        double durabilidadPico = picoPiedra.durabilidad();
+        int fuerzaPicoPiedra = picoPiedra.fuerza();
+        picoPiedra.golpear(bloquePiedra);
+
+        Assert.assertEquals(picoPiedra.durabilidad(),durabilidadPico - fuerzaPicoPiedra);
+    }
+
+    @Test
+    public void test20PicoPiedraGolpeaMetalYSeReduceSuDurabilidad() {
+
+        Metal bloqueMetal = new Metal();
+        Pico picoPiedra = new Pico(new Piedra());
+
+        double durabilidadPico = picoPiedra.durabilidad();
+        int fuerzaPicoPiedra = picoPiedra.fuerza();
+        picoPiedra.golpear(bloqueMetal);
+
+        Assert.assertEquals(picoPiedra.durabilidad(),durabilidadPico - fuerzaPicoPiedra);
+    }
 }


### PR DESCRIPTION
Agregué pruebas con el pico de piedra usando la durabilidad como double.

Intenté cambiar el atributo "durabilidad" de herramienta y ponerlo como double pero me choca con el assert de la durabilidad inicial (me dice que espera double, double). Nada, hay que ver cómo resolver eso y esto es más que nada como un recordatorio